### PR TITLE
Allow sorting tabs by last access time.

### DIFF
--- a/dist/options/options.html
+++ b/dist/options/options.html
@@ -45,6 +45,10 @@
                         <label>Search in URLs:</label>
                         <div id="option-search-urls" class="ui-switch"></div>
                     </div>
+                    <div class="option">
+                        <label>Show most recent tabs at top:</label>
+                        <div id="option-show-most-recent-top" class="ui-switch"></div>
+                    </div>
                 </div>
                 <div id="about" class="section">
                     <label>About</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tabby",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -56,6 +56,7 @@ function readOptions() {
         setSubOptionState(options.popup.showDetails, document.getElementById("option-preview").parentElement);
         setSwitchState(document.getElementById("option-hide-after-tab-switch"), options.popup.hideAfterTabSelection);
         setSwitchState(document.getElementById("option-search-urls"), options.popup.searchInURLs);
+        setSwitchState(document.getElementById("option-show-most-recent-top"), options.popup.sortByLastAccessed);
     });
 }
 
@@ -115,6 +116,13 @@ function addEventListeners() {
     document.getElementById("option-search-urls").addEventListener("input", e => {
         browser.storage.local.get(["options"]).then(data => {
             data.options.popup.searchInURLs = getSwitchState(e.target);
+            browser.storage.local.set(data);
+        });
+    });
+
+    document.getElementById("option-show-most-recent-top").addEventListener("input", e => {
+        browser.storage.local.get(["options"]).then(data => {
+            data.options.popup.sortByLastAccessed = getSwitchState(e.target);
             browser.storage.local.set(data);
         });
     });

--- a/src/popup/globals.js
+++ b/src/popup/globals.js
@@ -4,6 +4,7 @@ const globals = {
     tabsList: undefined,
     isSelecting: false,
     hideAfterTabSelection: undefined,
-    searchInURLs: undefined
+    searchInURLs: undefined,
+    sortByLastAccessed: undefined
 };
 export default globals;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -45,6 +45,8 @@ async function fulfillOptions() {
     G.hideAfterTabSelection = Options.stbool(popupOptions.hideAfterTabSelection);
     // popup.searchInURLs
     G.searchInURLs = Options.stbool(popupOptions.searchInURLs);
+    // popup.sortByLastAccessed
+    G.sortByLastAccessed = Options.stbool(popupOptions.sortByLastAccessed);
 }
 
 async function main() {

--- a/src/popup/wtinit.js
+++ b/src/popup/wtinit.js
@@ -114,6 +114,9 @@ export async function updateTabs(windows) {
 
         let windowTabsListFragment = document.createDocumentFragment();
         // Loop through tabs
+        if(G.sortByLastAccessed){
+            w.tabs.sort((a,b)=>a.lastAccessed < b.lastAccessed)
+        }
         for (let i = 0; i < w.tabs.length; i++) {
             let tab = w.tabs[i];
             // Check tab id


### PR DESCRIPTION
Thanks for the tabby, it's very useful and works nicely. I have feature suggestion.

Sorting tabs in a way that the ones I've opened most recently would show up at the top of the list.
Frequently I switch between same 4-5 tabs out of 50 open tabs. A feature like that would let us skip searching for most recent tabs and also help to remember what to search for if we are looking for a tab that is at the tenth place (so writing part of its name is faster than hitting down arrow ten times)
